### PR TITLE
Fix context menu player handling

### DIFF
--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -9,10 +9,14 @@ local function getClickedSquare(worldobjects)
     return nil
 end
 
-local function addMenu(playerNum, context, worldobjects, test)
+local function addContextMenuOptions(playerIndex, context, worldobjects, test)
     if test then return end
 
+    local player = getSpecificPlayer(playerIndex)
+    if not player then return end
+
     local sq = getClickedSquare(worldobjects)
+    if not sq then sq = player:getSquare() end
     if not sq then return end
 
     context:addOption("Designate Wood Pile Here", sq, function(targetSq)
@@ -26,9 +30,8 @@ local function addMenu(playerNum, context, worldobjects, test)
     end
 
     context:addOption("Auto-Chop Nearby Trees", sq, function()
-        local player = getSpecificPlayer(playerNum)
         AFCore.startJob(player)
     end)
 end
 
-Events.OnFillWorldObjectContextMenu.Add(addMenu)
+Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)


### PR DESCRIPTION
## Summary
- Fix context menu hook to use player index and fetch player safely
- Ensure context menu event is registered with updated function name

## Testing
- `find 42/media/lua -name '*.lua' -print0 | xargs -0 -n1 -I{} sh -c 'luac -p {}'` *(fails: luac: not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a228430518832e9ee3edf1f3a6ee25