### PR TITLE
fix: guard context menu when pawn or map missing

### DIFF
--- a/common/AutoForester.cs
+++ b/common/AutoForester.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+using Verse.AI;
+
+namespace AutoForester
+{
+    [HarmonyPatch(typeof(FloatMenuMakerMap), nameof(FloatMenuMakerMap.AddHumanlikeOrders))]
+    public static class ContextMenuPatch
+    {
+        static void Postfix(Vector3 clickPos, Pawn pawn, List<FloatMenuOption> opts)
+        {
+            // bail out if the pawn or its map are missing
+            if (pawn == null || pawn.Map == null)
+            {
+                return;
+            }
+
+            IntVec3 cell = IntVec3.FromVector3(clickPos);
+            if (!cell.IsValid || cell.GetPlant(pawn.Map) == null)
+            {
+                return;
+            }
+
+            var jobDef = DefDatabase<JobDef>.GetNamedSilentFail("AutoForestJob");
+            if (jobDef == null)
+            {
+                return;
+            }
+
+            opts.Add(new FloatMenuOption("Auto-Forest", () =>
+            {
+                Job job = JobMaker.MakeJob(jobDef, cell);
+                pawn.jobs.TryTakeOrderedJob(job);
+            }));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- guard RimWorld context menu patch when pawn or map is null
- verify clicked cell contains a plant before adding Auto-Forest option

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 from repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a25ce66858832ea56957630e06736f