### PR TITLE
fix: noisy callbacks and lazy core require

### DIFF
--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -1,81 +1,97 @@
--- Context menu hook (robust + lazy-require)
+-- AutoForester context menu (robust + loud)
 local function dbg(msg) print("[AutoForester] "..tostring(msg)) end
 dbg("Context file loaded")
 
-local function getSafeSquare(playerIndex, worldobjects)
-  -- mouse
-  local sq = getMouseSquare and getMouseSquare() or nil
-  if sq then return sq end
-  -- worldobjects
-  if worldobjects then
-    local first = worldobjects.get and worldobjects:get(0) or worldobjects[1]
-    if first and first.getSquare then
-      local s = first:getSquare()
-      if s then return s end
-    end
-  end
-  -- player
-  local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
-  if p and p.getSquare then return p:getSquare() end
-  return nil
+local function say(playerIndex, text)
+    local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
+    if p and p.Say then p:Say(text) end
 end
 
-local function lazyCore()
-  local ok, mod = pcall(require, "AutoForester_Core")
-  if not ok then
-    print("[AutoForester][WARN] Core not available: "..tostring(mod))
+local function getSafeSquare(playerIndex, worldobjects)
+    local sq = getMouseSquare and getMouseSquare() or nil
+    if sq then return sq end
+    if worldobjects then
+        local first = worldobjects.get and worldobjects:get(0) or worldobjects[1]
+        if first and first.getSquare then
+            local s = first:getSquare()
+            if s then return s end
+        end
+    end
+    local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
+    if p and p.getSquare then return p:getSquare() end
     return nil
-  end
-  return mod
+end
+
+local function lazyCore(playerIndex)
+    local ok, mod = pcall(require, "AutoForester_Core")
+    if not ok or type(mod) ~= "table" then
+        local err = (not ok) and tostring(mod) or "module returned "..type(mod)
+        print("[AutoForester][ERROR] require('AutoForester_Core') failed: "..err)
+        say(playerIndex, "AutoForester core missing/failed. See console.")
+        return nil
+    end
+    return mod
 end
 
 local function addContextMenuOptions(playerIndex, context, worldobjects, test)
-  -- Prove hook is alive (always add)
-  context:addOption("AutoForester: Debug (hook loaded)", nil, function()
-    local p = getSpecificPlayer(playerIndex or 0)
-    if p and p.Say then p:Say("AF: hook OK") end
-  end)
-
-  if test then return end
-
-  local sq = getSafeSquare(playerIndex, worldobjects)
-  -- show options even if we couldn't resolve a square yet; the callbacks re-resolve
-  context:addOption("Designate Wood Pile Here", sq, function(targetSq)
-    local core = lazyCore(); if not core then return end
-    targetSq = targetSq or getSafeSquare(playerIndex, worldobjects)
-    if targetSq then core.setStockpile(targetSq) end
-  end)
-
-  context:addOption("Auto-Chop Nearby Trees", sq, function()
-    local core = lazyCore(); if not core then return end
-    local p = getSpecificPlayer(playerIndex or 0)
-    if p then core.startJob(p) end
-  end)
-
-  local core = lazyCore()
-  if core and core.hasStockpile() then
-    context:addOption("Clear Wood Pile Marker", nil, function()
-      core.clearStockpile()
+    -- Heartbeat entry to prove the hook is alive
+    context:addOption("AutoForester: Debug (hook loaded)", nil, function()
+        say(playerIndex, "AF: hook OK")
     end)
-  end
+
+    -- Always-on test button to prove callbacks execute
+    context:addOption("AutoForester: Test Hello", nil, function()
+        print("[AutoForester] Test Hello clicked")
+        say(playerIndex, "Hello from AutoForester")
+    end)
+
+    if test then return end
+
+    local sq = getSafeSquare(playerIndex, worldobjects)
+
+    context:addOption("Designate Wood Pile Here", sq, function(targetSq)
+        print("[AutoForester] Designate clicked")
+        local core = lazyCore(playerIndex); if not core then return end
+        targetSq = targetSq or getSafeSquare(playerIndex, worldobjects)
+        if not targetSq then say(playerIndex, "No square"); return end
+        core.setStockpile(targetSq)
+        say(playerIndex, "Stockpile set.")
+    end)
+
+    context:addOption("Auto-Chop Nearby Trees", sq, function()
+        print("[AutoForester] Auto-Chop clicked")
+        local core = lazyCore(playerIndex); if not core then return end
+        local p = getSpecificPlayer(playerIndex or 0)
+        if not p then say(playerIndex, "No player"); return end
+        core.startJob(p)
+    end)
+
+    -- Only show if a pile exists
+    local core = lazyCore(playerIndex)
+    if core and core.hasStockpile() then
+        context:addOption("Clear Wood Pile Marker", nil, function()
+            print("[AutoForester] Clear Stockpile clicked")
+            local c = lazyCore(playerIndex); if not c then return end
+            c.clearStockpile()
+            say(playerIndex, "Stockpile cleared.")
+        end)
+    end
 end
 
--- Safe, deferred registration (handles load order)
+-- Safe, deferred registration to avoid nil Events during load
 local function registerAFContext()
-  if Events and Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
-    Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)
-    print("[AutoForester] Context hook registered")
-  else
-    if Events and Events.OnCreatePlayer and Events.OnCreatePlayer.Add then
-      Events.OnCreatePlayer.Add(function()
-        if Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
-          Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)
-          print("[AutoForester] Context hook registered (OnCreatePlayer)")
-        else
-          print("[AutoForester][WARN] Context event unavailable; skipping")
-        end
-      end)
+    if Events and Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
+        Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)
+        print("[AutoForester] Context hook registered")
+    elseif Events and Events.OnCreatePlayer and Events.OnCreatePlayer.Add then
+        Events.OnCreatePlayer.Add(function()
+            if Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
+                Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)
+                print("[AutoForester] Context hook registered (OnCreatePlayer)")
+            else
+                print("[AutoForester][WARN] Context event unavailable; skipping")
+            end
+        end)
     end
-  end
 end
 Events.OnGameStart.Add(registerAFContext)

--- a/42/media/lua/shared/AutoForester_Core.lua
+++ b/42/media/lua/shared/AutoForester_Core.lua
@@ -1,182 +1,127 @@
--- AutoForester Core (B42) – shared so client/server can see it
-local Shared = require("AutoForester_Shared")
+-- AutoForester Core (B42) – must return a table
+print("[AutoForester] Core file loading")
 
+local Shared = require("AutoForester_Shared")
 local AFCore = {
-  _queue = nil,
-  _index = 0,
-  _busy  = false,
-  _lastPulse = 0,
+  _queue = nil, _index = 0, _busy = false, _lastPulse = 0
 }
 
 local function dbg(msg) print("[AutoForester] "..tostring(msg)) end
+local function say(p, s) if p and p.Say then p:Say(s) end end
 
--- Public API
-function AFCore.hasStockpile()
-  return Shared and Shared.Stockpile ~= nil
-end
-
+function AFCore.hasStockpile() return Shared and Shared.Stockpile ~= nil end
 function AFCore.setStockpile(square)
-  if not Shared then return end
-  if not square then return end
+  if not (Shared and square) then return end
   Shared.Stockpile = { x = square:getX(), y = square:getY(), z = square:getZ() }
-  dbg(("Stockpile set at %d,%d,%d"):format(Shared.Stockpile.x, Shared.Stockpile.y, Shared.Stockpile.z))
+  dbg(("Stockpile set @ %d,%d,%d"):format(Shared.Stockpile.x, Shared.Stockpile.y, Shared.Stockpile.z))
 end
+function AFCore.clearStockpile() if Shared then Shared.Stockpile = nil end dbg("Stockpile cleared") end
 
-function AFCore.clearStockpile()
-  if not Shared then return end
-  Shared.Stockpile = nil
-  dbg("Stockpile cleared")
-end
-
--- Collect nearby trees (simple sweep; we can tune later)
-local function findNearbyTrees(player, radius)
+local function findNearbyTrees(player, r)
   local out = {}
-  if not player then return out end
-  local cell = getCell()
-  local sq = player:getSquare()
-  if not sq then return out end
-  local z = sq:getZ()
-  for dx = -radius, radius do
-    for dy = -radius, radius do
-      local gs = cell:getGridSquare(sq:getX()+dx, sq:getY()+dy, z)
-      if gs then
-        local objs = gs:getObjects()
-        if objs then
-          for i=0, objs:size()-1 do
-            local o = objs:get(i)
-            if o and instanceof(o, "IsoTree") then table.insert(out, { tree=o, square=gs }) end
-          end
+  if not (player and player.getSquare) then return out end
+  local sq = player:getSquare(); if not sq then return out end
+  local cell, z = getCell(), sq:getZ()
+  for dx=-r,r do for dy=-r,r do
+    local gs = cell:getGridSquare(sq:getX()+dx, sq:getY()+dy, z)
+    if gs then
+      local objs = gs:getObjects()
+      if objs then
+        for i=0, objs:size()-1 do
+          local o = objs:get(i)
+          if o and instanceof(o, "IsoTree") then table.insert(out, {tree=o, square=gs}) end
         end
       end
     end
-  end
+  end end
   return out
 end
 
--- Tiny instant action to chain logic inside the queue
 local AFInstantAction = ISBaseTimedAction:derive("AFInstantAction")
 function AFInstantAction:isValid() return true end
 function AFInstantAction:waitToStart() return false end
-function AFInstantAction:update() end
-function AFInstantAction:start() end
-function AFInstantAction:stop() ISBaseTimedAction.stop(self) end
-function AFInstantAction:perform()
-  if self.func then pcall(self.func) end
-  ISBaseTimedAction.perform(self)
-end
-function AFInstantAction:new(player, func)
-  local o = ISBaseTimedAction.new(self, player)
-  o.func = func
-  o.maxTime = 1
-  return o
-end
+function AFInstantAction:perform() if self.func then pcall(self.func) end ISBaseTimedAction.perform(self) end
+function AFInstantAction:new(player, func) local o=ISBaseTimedAction.new(self, player); o.func=func; o.maxTime=1; return o end
 
-local function queueWalkTo(player, targetSq)
-  if not player or not targetSq then return end
-  ISTimedActionQueue.add(ISWalkToAction:new(player, targetSq))
-end
-
-local function dropAllWood(player)
-  local inv = player and player:getInventory()
-  if not inv then return end
+local function queueWalkTo(p, sq) if p and sq then ISTimedActionQueue.add(ISWalkToAction:new(p, sq)) end end
+local function dropAllWood(p)
+  local inv = p and p:getInventory(); if not inv then return end
   local items = inv:getItems()
-  for i = items:size()-1, 0, -1 do
+  for i=items:size()-1,0,-1 do
     local it = items:get(i)
-    if it and Shared.ITEM_TYPES[it:getType()] then
-      ISTimedActionQueue.add(ISDropItemAction:new(player, it))
-    end
+    if it and Shared.ITEM_TYPES[it:getType()] then ISTimedActionQueue.add(ISDropItemAction:new(p, it)) end
   end
 end
-
-local function getStockpileSquare()
-  local sp = Shared and Shared.Stockpile
-  if not sp then return nil end
+local function pileSquare()
+  local sp = Shared and Shared.Stockpile; if not sp then return nil end
   return getCell():getGridSquare(sp.x, sp.y, sp.z)
 end
 
-local function step(player)
+local function step(p)
   AFCore._lastPulse = getTimestampMs and getTimestampMs() or (AFCore._lastPulse + 1)
   if not AFCore._queue or AFCore._index > #AFCore._queue then
-    AFCore._busy = false
-    if player and player.Say then player:Say("AutoForester job complete.") end
-    return
+    AFCore._busy=false; say(p,"AutoForester complete."); dbg("Job complete"); return
   end
+  local job = AFCore._queue[AFCore._index]; AFCore._index = AFCore._index + 1
+  if not (job and job.tree and job.square) then dbg("Skip invalid job"); return step(p) end
 
-  local job = AFCore._queue[AFCore._index]
-  AFCore._index = AFCore._index + 1
+  dbg(("Step: walk→chop @ %d,%d"):format(job.square:getX(), job.square:getY()))
+  queueWalkTo(p, job.square)
+  ISTimedActionQueue.add(ISChopTreeAction:new(p, job.tree))
 
-  if not job or not job.tree or not job.square then
-    step(player)
-    return
-  end
-
-  -- Walk → Chop → Pickup → Deliver → Continue
-  queueWalkTo(player, job.square)
-  ISTimedActionQueue.add(ISChopTreeAction:new(player, job.tree))
-
-  local radius = 1
-  ISTimedActionQueue.add(AFInstantAction:new(player, function()
-    local drops = {}
+  local r=1
+  ISTimedActionQueue.add(AFInstantAction:new(p, function()
+    dbg("Sweep for drops")
     local cell = getCell()
-    for dx=-radius,radius do
-      for dy=-radius,radius do
-        local s = cell:getGridSquare(job.square:getX()+dx, job.square:getY()+dy, job.square:getZ())
-        local wios = s and s:getWorldObjects()
-        if wios then
-          for i=0,wios:size()-1 do
-            local wio = wios:get(i)
-            local item = wio and wio:getItem()
-            if item and Shared.ITEM_TYPES[item:getType()] then
-              ISTimedActionQueue.add(ISGrabItemAction:new(player, wio, 5))
-            end
+    for dx=-r,r do for dy=-r,r do
+      local s = cell:getGridSquare(job.square:getX()+dx, job.square:getY()+dy, job.square:getZ())
+      local wios = s and s:getWorldObjects()
+      if wios then
+        for i=0,wios:size()-1 do
+          local wio = wios:get(i); local item = wio and wio:getItem()
+          if item and Shared.ITEM_TYPES[item:getType()] then
+            ISTimedActionQueue.add(ISGrabItemAction:new(p, wio, 5))
           end
         end
       end
-    end
+    end end
   end))
 
-  local pile = getStockpileSquare()
+  local pile = pileSquare()
   if pile then
-    queueWalkTo(player, pile)
-    ISTimedActionQueue.add(AFInstantAction:new(player, function() dropAllWood(player) end))
+    dbg("Walk to pile & drop")
+    queueWalkTo(p, pile)
+    ISTimedActionQueue.add(AFInstantAction:new(p, function() dropAllWood(p) end))
   end
 
-  ISTimedActionQueue.add(AFInstantAction:new(player, function() step(player) end))
+  ISTimedActionQueue.add(AFInstantAction:new(p, function() step(p) end))
 end
 
-function AFCore.startJob(player)
-  if not player then return end
-  if AFCore._busy then
-    if player.Say then player:Say("Already working, please wait.") end
-    return
-  end
-  local trees = findNearbyTrees(player, 8) -- radius; can be made configurable
-  AFCore._queue = trees
-  AFCore._index = 1
-  AFCore._busy = true
-  if player.Say then player:Say(("Queued %d tree(s)."):format(#trees)) end
-  local ok, err = pcall(function() step(player) end)
+function AFCore.startJob(p)
+  if AFCore._busy then say(p,"Already working…"); dbg("Start blocked: busy"); return end
+  if not p then dbg("No player"); return end
+  local list = findNearbyTrees(p, 8)
+  AFCore._queue, AFCore._index, AFCore._busy = list, 1, true
+  say(p, ("Queued %d tree(s)."):format(#list))
+  dbg(("Queued %d tree(s)"):format(#list))
+  local ok, err = pcall(function() step(p) end)
   if not ok then
-    AFCore._busy = false
-    AFCore._queue = nil
-    print("[AutoForester][ERROR] "..tostring(err))
-    if player.Say then player:Say("AutoForester error; queue cleared.") end
+    AFCore._busy=false; AFCore._queue=nil; print("[AutoForester][ERROR] "..tostring(err)); say(p, "Error; queue cleared")
   end
 end
 
--- Watchdog to prevent “busy but idle” dead-locks
 local function watchdog()
   if not AFCore._busy then return end
-  local p = getSpecificPlayer(0)
-  if not p then return end
+  local p = getSpecificPlayer(0); if not p then return end
   local q = ISTimedActionQueue.getTimedActionQueue(p)
-  local empty = not (q and q.queue and q.queue:size() > 0)
+  local empty = not (q and q.queue and q.queue:size()>0)
   local now = getTimestampMs and getTimestampMs() or 0
   if empty and now and (now - (AFCore._lastPulse or now)) > 4000 then
-    print("[AutoForester] Watchdog pulse: advancing")
+    print("[AutoForester] Watchdog: nudging step")
     step(p)
   end
 end
 Events.EveryOneSecond.Add(watchdog)
 
+print("[AutoForester] Core file loaded OK")
 return AFCore


### PR DESCRIPTION
## Summary
- make context menu callbacks loud and robust, with Test Hello button
- lazy-require core module and warn on failure
- refactor core to return table, log loading, and print queue steps

## Testing
- `luac -p 42/media/lua/client/AutoForester_Context.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a27c9c6bd0832e952d95f0ff863f79