### PR TITLE
fix: stabilize AutoForester event registration and actions

### DIFF
--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -1,97 +1,80 @@
--- AutoForester context menu (robust + loud)
-local function dbg(msg) print("[AutoForester] "..tostring(msg)) end
+local function dbg(m) print("[AutoForester] "..tostring(m)) end
 dbg("Context file loaded")
 
-local function say(playerIndex, text)
-    local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
-    if p and p.Say then p:Say(text) end
+local function say(pi, txt)
+  local p = getSpecificPlayer and getSpecificPlayer(pi or 0)
+  if p and p.Say then p:Say(txt) end
 end
 
-local function getSafeSquare(playerIndex, worldobjects)
-    local sq = getMouseSquare and getMouseSquare() or nil
-    if sq then return sq end
-    if worldobjects then
-        local first = worldobjects.get and worldobjects:get(0) or worldobjects[1]
-        if first and first.getSquare then
-            local s = first:getSquare()
-            if s then return s end
-        end
+local function getSafeSquare(pi, wos)
+  -- 1) Mouse square (guarded)
+  local ms = _G.getMouseSquare
+  local sq = (type(ms)=="function") and ms() or nil
+  if sq and sq.getX then return sq end
+
+  -- 2) Worldobjects (ArrayList or Lua table)
+  if wos then
+    local first = (wos.get and wos:get(0)) or wos[1]
+    if first and first.getSquare then
+      local s = first:getSquare()
+      if s then return s end
     end
-    local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
-    if p and p.getSquare then return p:getSquare() end
+  end
+
+  -- 3) Player square
+  local p = getSpecificPlayer and getSpecificPlayer(pi or 0)
+  if p and p.getSquare then
+    local ps = p:getSquare()
+    if ps then return ps end
+  end
+  return nil
+end
+
+local function core()
+  local ok, mod = pcall(require, "AutoForester_Core")
+  if not ok or type(mod) ~= "table" then
+    print("[AutoForester][ERROR] require Core failed: "..tostring(mod))
     return nil
+  end
+  return mod
 end
 
-local function lazyCore(playerIndex)
-    local ok, mod = pcall(require, "AutoForester_Core")
-    if not ok or type(mod) ~= "table" then
-        local err = (not ok) and tostring(mod) or "module returned "..type(mod)
-        print("[AutoForester][ERROR] require('AutoForester_Core') failed: "..err)
-        say(playerIndex, "AutoForester core missing/failed. See console.")
-        return nil
-    end
-    return mod
+local function addMenu(pi, context, wos, test)
+  context:addOption("AutoForester: Debug (hook loaded)", nil, function() say(pi, "AF: hook OK") end)
+  if test then return end
+
+  local sq = getSafeSquare(pi, wos)
+
+  context:addOption("Designate Wood Pile Here", sq, function(targetSq)
+    local c = core(); if not c then say(pi,"Core missing"); return end
+    targetSq = targetSq or getSafeSquare(pi, wos)
+    if targetSq then c.setStockpile(targetSq); say(pi,"Wood pile set.") end
+  end)
+
+  context:addOption("Auto-Chop Nearby Trees", sq, function()
+    local c = core(); if not c then say(pi,"Core missing"); return end
+    local p = getSpecificPlayer(pi or 0); if not p then say(pi,"No player"); return end
+    c.startJob(p)
+  end)
+
+  local c = core()
+  if c and c.hasStockpile() then
+    context:addOption("Clear Wood Pile Marker", nil, function() c.clearStockpile(); say(pi,"Wood pile cleared.") end)
+  end
 end
 
-local function addContextMenuOptions(playerIndex, context, worldobjects, test)
-    -- Heartbeat entry to prove the hook is alive
-    context:addOption("AutoForester: Debug (hook loaded)", nil, function()
-        say(playerIndex, "AF: hook OK")
+-- Safe, deferred registration
+local function register()
+  if Events and Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
+    Events.OnFillWorldObjectContextMenu.Add(addMenu)
+    print("[AutoForester] Context hook registered")
+  elseif Events and Events.OnCreatePlayer and Events.OnCreatePlayer.Add then
+    Events.OnCreatePlayer.Add(function()
+      if Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
+        Events.OnFillWorldObjectContextMenu.Add(addMenu)
+        print("[AutoForester] Context hook registered (OnCreatePlayer)")
+      end
     end)
-
-    -- Always-on test button to prove callbacks execute
-    context:addOption("AutoForester: Test Hello", nil, function()
-        print("[AutoForester] Test Hello clicked")
-        say(playerIndex, "Hello from AutoForester")
-    end)
-
-    if test then return end
-
-    local sq = getSafeSquare(playerIndex, worldobjects)
-
-    context:addOption("Designate Wood Pile Here", sq, function(targetSq)
-        print("[AutoForester] Designate clicked")
-        local core = lazyCore(playerIndex); if not core then return end
-        targetSq = targetSq or getSafeSquare(playerIndex, worldobjects)
-        if not targetSq then say(playerIndex, "No square"); return end
-        core.setStockpile(targetSq)
-        say(playerIndex, "Stockpile set.")
-    end)
-
-    context:addOption("Auto-Chop Nearby Trees", sq, function()
-        print("[AutoForester] Auto-Chop clicked")
-        local core = lazyCore(playerIndex); if not core then return end
-        local p = getSpecificPlayer(playerIndex or 0)
-        if not p then say(playerIndex, "No player"); return end
-        core.startJob(p)
-    end)
-
-    -- Only show if a pile exists
-    local core = lazyCore(playerIndex)
-    if core and core.hasStockpile() then
-        context:addOption("Clear Wood Pile Marker", nil, function()
-            print("[AutoForester] Clear Stockpile clicked")
-            local c = lazyCore(playerIndex); if not c then return end
-            c.clearStockpile()
-            say(playerIndex, "Stockpile cleared.")
-        end)
-    end
+  end
 end
-
--- Safe, deferred registration to avoid nil Events during load
-local function registerAFContext()
-    if Events and Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
-        Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)
-        print("[AutoForester] Context hook registered")
-    elseif Events and Events.OnCreatePlayer and Events.OnCreatePlayer.Add then
-        Events.OnCreatePlayer.Add(function()
-            if Events.OnFillWorldObjectContextMenu and Events.OnFillWorldObjectContextMenu.Add then
-                Events.OnFillWorldObjectContextMenu.Add(addContextMenuOptions)
-                print("[AutoForester] Context hook registered (OnCreatePlayer)")
-            else
-                print("[AutoForester][WARN] Context event unavailable; skipping")
-            end
-        end)
-    end
-end
-Events.OnGameStart.Add(registerAFContext)
+Events.OnGameStart.Add(register)

--- a/42/media/lua/shared/AutoForester_Core.lua
+++ b/42/media/lua/shared/AutoForester_Core.lua
@@ -1,127 +1,152 @@
--- AutoForester Core (B42) – must return a table
 print("[AutoForester] Core file loading")
 
 local Shared = require("AutoForester_Shared")
-local AFCore = {
-  _queue = nil, _index = 0, _busy = false, _lastPulse = 0
-}
+local Core = { _queue=nil, _i=0, _busy=false, _lastPulse=0 }
 
-local function dbg(msg) print("[AutoForester] "..tostring(msg)) end
-local function say(p, s) if p and p.Say then p:Say(s) end end
+local function dbg(m) print("[AutoForester] "..tostring(m)) end
+local function say(p, m) if p and p.Say then p:Say(m) end
 
-function AFCore.hasStockpile() return Shared and Shared.Stockpile ~= nil end
-function AFCore.setStockpile(square)
-  if not (Shared and square) then return end
-  Shared.Stockpile = { x = square:getX(), y = square:getY(), z = square:getZ() }
-  dbg(("Stockpile set @ %d,%d,%d"):format(Shared.Stockpile.x, Shared.Stockpile.y, Shared.Stockpile.z))
+function Core.hasStockpile() return Shared and Shared.Stockpile ~= nil end
+function Core.setStockpile(sq)
+  if not (Shared and sq) then return end
+  Shared.setPile(sq)
+  dbg(("Stockpile set at %d,%d,%d"):format(sq:getX(), sq:getY(), sq:getZ()))
 end
-function AFCore.clearStockpile() if Shared then Shared.Stockpile = nil end dbg("Stockpile cleared") end
+function Core.clearStockpile() Shared.clearPile(); dbg("Stockpile cleared") end
 
-local function findNearbyTrees(player, r)
-  local out = {}
-  if not (player and player.getSquare) then return out end
-  local sq = player:getSquare(); if not sq then return out end
-  local cell, z = getCell(), sq:getZ()
+local function squaresAround(sq, r)
+  local out, cell, z = {}, getCell(), sq:getZ()
   for dx=-r,r do for dy=-r,r do
-    local gs = cell:getGridSquare(sq:getX()+dx, sq:getY()+dy, z)
-    if gs then
-      local objs = gs:getObjects()
-      if objs then
-        for i=0, objs:size()-1 do
-          local o = objs:get(i)
-          if o and instanceof(o, "IsoTree") then table.insert(out, {tree=o, square=gs}) end
-        end
-      end
-    end
+    local s = cell:getGridSquare(sq:getX()+dx, sq:getY()+dy, z)
+    if s then out[#out+1] = s end
   end end
   return out
 end
 
-local AFInstantAction = ISBaseTimedAction:derive("AFInstantAction")
-function AFInstantAction:isValid() return true end
-function AFInstantAction:waitToStart() return false end
-function AFInstantAction:perform() if self.func then pcall(self.func) end ISBaseTimedAction.perform(self) end
-function AFInstantAction:new(player, func) local o=ISBaseTimedAction.new(self, player); o.func=func; o.maxTime=1; return o end
-
-local function queueWalkTo(p, sq) if p and sq then ISTimedActionQueue.add(ISWalkToAction:new(p, sq)) end end
-local function dropAllWood(p)
-  local inv = p and p:getInventory(); if not inv then return end
-  local items = inv:getItems()
-  for i=items:size()-1,0,-1 do
-    local it = items:get(i)
-    if it and Shared.ITEM_TYPES[it:getType()] then ISTimedActionQueue.add(ISDropItemAction:new(p, it)) end
+local function findNearbyTrees(originSq, r)
+  local trees = {}
+  for _, s in ipairs(squaresAround(originSq, r)) do
+    local objs = s:getObjects()
+    if objs then
+      for i=0, objs:size()-1 do
+        local o = objs:get(i)
+        if o and instanceof(o, "IsoTree") then trees[#trees+1] = {tree=o, square=s} end
+      end
+    end
   end
-end
-local function pileSquare()
-  local sp = Shared and Shared.Stockpile; if not sp then return nil end
-  return getCell():getGridSquare(sp.x, sp.y, sp.z)
+  return trees
 end
 
-local function step(p)
-  AFCore._lastPulse = getTimestampMs and getTimestampMs() or (AFCore._lastPulse + 1)
-  if not AFCore._queue or AFCore._index > #AFCore._queue then
-    AFCore._busy=false; say(p,"AutoForester complete."); dbg("Job complete"); return
-  end
-  local job = AFCore._queue[AFCore._index]; AFCore._index = AFCore._index + 1
-  if not (job and job.tree and job.square) then dbg("Skip invalid job"); return step(p) end
+-- Mini action for inline callbacks in queue
+local AFInstant = ISBaseTimedAction:derive("AFInstant")
+function AFInstant:isValid() return true end
+function AFInstant:waitToStart() return false end
+function AFInstant:perform() if self.func then pcall(self.func) end ISBaseTimedAction.perform(self) end
+function AFInstant:new(p, fn) local o=ISBaseTimedAction.new(self, p); o.func=fn; o.maxTime=1; return o end
 
-  dbg(("Step: walk→chop @ %d,%d"):format(job.square:getX(), job.square:getY()))
-  queueWalkTo(p, job.square)
-  ISTimedActionQueue.add(ISChopTreeAction:new(p, job.tree))
+local function queueWalkTo(p, sq)
+  if p and sq then ISTimedActionQueue.add(ISWalkToAction:new(p, sq)) end
+end
 
-  local r=1
-  ISTimedActionQueue.add(AFInstantAction:new(p, function()
-    dbg("Sweep for drops")
+local function queueLootSweep(p, stumpSq, r)
+  ISTimedActionQueue.add(AFInstant:new(p, function()
     local cell = getCell()
     for dx=-r,r do for dy=-r,r do
-      local s = cell:getGridSquare(job.square:getX()+dx, job.square:getY()+dy, job.square:getZ())
+      local s = cell:getGridSquare(stumpSq:getX()+dx, stumpSq:getY()+dy, stumpSq:getZ())
       local wios = s and s:getWorldObjects()
       if wios then
-        for i=0,wios:size()-1 do
-          local wio = wios:get(i); local item = wio and wio:getItem()
-          if item and Shared.ITEM_TYPES[item:getType()] then
+        for i=0, wios:size()-1 do
+          local wio = wios:get(i); local it = wio and wio:getItem()
+          if it and Shared.ITEM_TYPES[it:getType()] then
             ISTimedActionQueue.add(ISGrabItemAction:new(p, wio, 5))
           end
         end
       end
     end end
   end))
-
-  local pile = pileSquare()
-  if pile then
-    dbg("Walk to pile & drop")
-    queueWalkTo(p, pile)
-    ISTimedActionQueue.add(AFInstantAction:new(p, function() dropAllWood(p) end))
-  end
-
-  ISTimedActionQueue.add(AFInstantAction:new(p, function() step(p) end))
 end
 
-function AFCore.startJob(p)
-  if AFCore._busy then say(p,"Already working…"); dbg("Start blocked: busy"); return end
-  if not p then dbg("No player"); return end
-  local list = findNearbyTrees(p, 8)
-  AFCore._queue, AFCore._index, AFCore._busy = list, 1, true
-  say(p, ("Queued %d tree(s)."):format(#list))
-  dbg(("Queued %d tree(s)"):format(#list))
+local function queueDropAtPile(p)
+  local pile = Shared.getPileSquare()
+  if not pile then return end
+  queueWalkTo(p, pile)
+  ISTimedActionQueue.add(AFInstant:new(p, function()
+    local items = p:getInventory():getItems()
+    for i=items:size()-1,0,-1 do
+      local it = items:get(i)
+      if it and Shared.ITEM_TYPES[it:getType()] then
+        ISTimedActionQueue.add(ISDropItemAction:new(p, it))
+      end
+    end
+    Shared.say(p, "Delivered to wood pile.")
+  end))
+end
+
+local function step(p)
+  Core._lastPulse = (type(getTimestampMs)=="function") and getTimestampMs() or (Core._lastPulse + 1)
+  if not Core._queue or Core._i > #Core._queue then
+    Core._busy=false; Shared.say(p,"AutoForester complete."); dbg("Job complete"); return
+  end
+  local job = Core._queue[Core._i]; Core._i = Core._i + 1
+  if not (job and job.tree and job.square) then return step(p) end
+
+  dbg(("Step walk→chop @ %d,%d"):format(job.square:getX(), job.square:getY()))
+  queueWalkTo(p, job.square)
+  ISTimedActionQueue.add(ISChopTreeAction:new(p, job.tree))
+  queueLootSweep(p, job.square, Shared.cfg.sweepRadius or 1)
+  queueDropAtPile(p)
+  ISTimedActionQueue.add(AFInstant:new(p, function() step(p) end))
+end
+
+function Core.startJob(p)
+  if Core._busy then Shared.say(p,"Already working…"); return end
+  if not p then return end
+  local origin = p:getSquare(); if not origin then return end
+  local trees = findNearbyTrees(origin, Shared.cfg.radius or 12)
+
+  -- cap to avoid 80+ actions on first test
+  local cap = 25
+  if #trees > cap then
+    local t = {}; for i=1,cap do t[i]=trees[i] end; trees=t
+  end
+
+  Core._queue, Core._i, Core._busy = trees, 1, true
+  Shared.say(p, ("Queued %d tree(s)."):format(#trees)); dbg(("Queued %d tree(s)"):format(#trees))
   local ok, err = pcall(function() step(p) end)
   if not ok then
-    AFCore._busy=false; AFCore._queue=nil; print("[AutoForester][ERROR] "..tostring(err)); say(p, "Error; queue cleared")
+    Core._busy=false; Core._queue=nil
+    print("[AutoForester][ERROR] "..tostring(err)); Shared.say(p, "Error; queue cleared")
   end
 end
 
+-- Register watchdog ONLY when Events is ready (fixes 'Add of non-table: null')
 local function watchdog()
-  if not AFCore._busy then return end
-  local p = getSpecificPlayer(0); if not p then return end
+  if not Core._busy then return end
+  local p = getSpecificPlayer and getSpecificPlayer(0)
+  if not p then return end
   local q = ISTimedActionQueue.getTimedActionQueue(p)
-  local empty = not (q and q.queue and q.queue:size()>0)
-  local now = getTimestampMs and getTimestampMs() or 0
-  if empty and now and (now - (AFCore._lastPulse or now)) > 4000 then
+  local empty = not (q and q.queue and q.queue:size() > 0)
+  local now = (type(getTimestampMs)=="function") and getTimestampMs() or 0
+  if empty and now and (now - (Core._lastPulse or now)) > 4000 then
     print("[AutoForester] Watchdog: nudging step")
     step(p)
   end
 end
-Events.EveryOneSecond.Add(watchdog)
+
+local function registerWatchdog()
+  if Events and Events.EveryOneSecond and Events.EveryOneSecond.Add then
+    Events.EveryOneSecond.Add(watchdog)
+    print("[AutoForester] Watchdog registered")
+  elseif Events and Events.OnGameStart and Events.OnGameStart.Add then
+    Events.OnGameStart.Add(function()
+      if Events.EveryOneSecond and Events.EveryOneSecond.Add then
+        Events.EveryOneSecond.Add(watchdog)
+        print("[AutoForester] Watchdog registered (OnGameStart)")
+      end
+    end)
+  end
+end
+registerWatchdog()
 
 print("[AutoForester] Core file loaded OK")
-return AFCore
+return Core

--- a/42/mod.info
+++ b/42/mod.info
@@ -1,4 +1,4 @@
 name=AutoForester (B42)
 id=AutoForester
-description=Right-click to set a wood stockpile, then auto-chop trees, collect logs/branches/twigs, and stack at your pile. Build 42 compatible.
-pack=AutoForester
+description=Auto-chop nearby trees, collect wood, and deliver to a designated pile.
+poster=poster.png


### PR DESCRIPTION
## Summary
- Harden context helper to avoid nil square calls and lazy-load Core
- Defer event registration and watchdog setup until Events table exists
- Drop unused `pack` field from mod info to silence console warning

## Testing
- `luac -p 42/media/lua/client/AutoForester_Context.lua 42/media/lua/shared/AutoForester_Core.lua` *(fails: command not found)*
- `apt-get update >/tmp/aptlog && tail -n 20 /tmp/aptlog` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a289326e24832e80b3d7d4c55efde5