### PR TITLE
Add debug-safe guards for area selection and drop logic

### DIFF
--- a/42/media/lua/client/AF_SelectArea.lua
+++ b/42/media/lua/client/AF_SelectArea.lua
@@ -52,13 +52,24 @@ function Tool.begin(kind)
 end
 
 local function getMouseSquare()
+    local player = getPlayer()
+    if not player then return nil end
+
     local mx, my = getMouseXScaled(), getMouseYScaled()
     local wx, wy = ISCoordConversion.ToWorld(mx, my, 0)
-    return getCell():getGridSquare(math.floor(wx), math.floor(wy), getPlayer():getZ())
+    if not wx or not wy then return nil end
+
+    return getCell():getGridSquare(math.floor(wx), math.floor(wy), player:getZ())
 end
 
 function Tool.onMouseDown(x,y)
     if not Tool.active then return false end
+
+    local player = getPlayer()
+    if not player or not getMouseWorldX or not getMouseWorldX() then
+        return false
+    end
+
     Tool.startSq = getMouseSquare()
     return false
 end


### PR DESCRIPTION
## Summary
- prevent crash on drag-select by ensuring player and mouse world coords exist before initializing selection
- add defensive checks and debug logging around drop pile delivery to trace issues

## Testing
- `luac -p 42/media/lua/client/AF_SelectArea.lua 42/media/lua/client/AutoChopTask.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a508fb2a48832eab97e5215ef6d78d