### PR TITLE
Refactor highlighting and chopping workflow

### DIFF
--- a/42/media/lua/client/AF_SelectArea.lua
+++ b/42/media/lua/client/AF_SelectArea.lua
@@ -1,107 +1,88 @@
-AF_SelectArea = AF_SelectArea or {}
-local Tool = AF_SelectArea
+AutoChopTask = AutoChopTask or {}
 
-local function getP()
-    return getSpecificPlayer and getSpecificPlayer(0) or getPlayer()
-end
-
-local function safeMouseSquare()
-    -- Robust against nils while opening menus / UI focus changes
-    local mx, my = getMouseXScaled(), getMouseYScaled()
-    if not mx or not my then return nil end
-    local wx, wy = ISCoordConversion.ToWorld(mx, my, 0)
-    if not wx or not wy then return nil end
-    wx, wy = math.floor(wx), math.floor(wy)
-    local z = (getP() and getP():getZ()) or 0
-    local cell = getCell()
-    return cell and cell:getGridSquare(wx, wy, z) or nil
-end
-
-Tool.active = false
-Tool.kind = nil         -- "chop" | "gather"
-Tool.startSq = nil
-Tool.rect = nil
-Tool.highlighted = {}
+local Tool = {
+  active = false,
+  startSq = nil,
+  rect = nil,
+  highlighted = {},
+  kind = "chop" -- or "gather", set by caller
+}
 
 local function clearHighlight()
-    for _, sq in ipairs(Tool.highlighted) do
-        sq:setHighlighted(false)
-    end
-    Tool.highlighted = {}
+  for _, sq in ipairs(Tool.highlighted) do
+    if sq and sq.setHighlighted then sq:setHighlighted(false) end
+  end
+  Tool.highlighted = {}
 end
 
 local function addHighlight(rect)
-    clearHighlight()
-    if not rect then return end
-    local x1,y1,x2,y2,z = table.unpack(rect)
-    local cell = getCell()
-    for x=x1,x2 do
-        for y=y1,y2 do
-            local sq = cell:getGridSquare(x,y,z)
-            if sq then
-                sq:setHighlighted(true)
-                sq:setHighlightColor(0,1,0,0.6)
-                table.insert(Tool.highlighted, sq)
-            end
-        end
+  clearHighlight()
+  if not rect then return end
+  local x1, y1, x2, y2 = table.unpack(rect)
+  local cell = getCell()
+  for x = x1, x2 do
+    for y = y1, y2 do
+      local sq = cell:getGridSquare(x, y, 0)
+      if sq and sq.setHighlighted then
+        sq:setHighlighted(true)
+        -- B42 NOTE: setHighlightColor is not guaranteed; do NOT call it.
+        table.insert(Tool.highlighted, sq)
+      end
     end
+  end
 end
 
 local function makeRect(a, b)
-    if not a or not b then return nil end
-    local z = a:getZ()
-    local r = { math.min(a:getX(), b:getX()),
-                math.min(a:getY(), b:getY()),
-                math.max(a:getX(), b:getX()),
-                math.max(a:getY(), b:getY()),
-                z }
-    return r
+  if not a or not b then return nil end
+  local z = a:getZ()
+  return { math.min(a:getX(), b:getX()), math.min(a:getY(), b:getY()),
+           math.max(a:getX(), b:getX()), math.max(a:getY(), b:getY()), z }
 end
 
-function Tool.begin(kind)
+function Tool.onMouseDown(x, y)
+  if not Tool.active then return false end
+  Tool.startSq = getMouseSquare()
+  return false
+end
+
+function Tool.onMouseMove(dx, dy)
+  if not Tool.active or not Tool.startSq then return false end
+  local cur = getMouseSquare()
+  if not cur then return false end
+  Tool.rect = makeRect(Tool.startSq, cur)
+  addHighlight(Tool.rect)
+  return false
+end
+
+function Tool.onMouseUp(x, y)
+  if not Tool.active then return false end
+  local cur = getMouseSquare()
+  if not cur then return false end
+  Tool.rect = makeRect(Tool.startSq, cur)
+  addHighlight(Tool.rect) -- final preview once more (safe)
+  if Tool.kind == "chop" then
+    AutoChopTask.chopRect = Tool.rect
+    getPlayer():Say("Chop area set.")
+  else
+    AutoChopTask.gatherRect = Tool.rect
+    getPlayer():Say("Gather area set.")
+  end
+  Tool.active = false
+  return false
+end
+
+AF_SelectArea = {
+  Start = function(kind)
+    Tool.kind = kind or "chop"
     Tool.active = true
-    Tool.kind = kind
     Tool.startSq = nil
     Tool.rect = nil
     clearHighlight()
-    getPlayer():Say("Drag to select "..kind.." area.")
-end
-
-function Tool.onMouseDown(x,y)
-    if not Tool.active then return false end
-    local sq = safeMouseSquare()
-    if not sq then return false end
-    Tool.startSq = sq
-    return false
-end
-
-function Tool.onMouseMove(dx,dy)
-    if not Tool.active or not Tool.startSq then return false end
-    local cur = safeMouseSquare()
-    if not cur then return false end
-    local rect = makeRect(Tool.startSq, cur)
-    Tool.rect = rect
-    addHighlight(rect)
-    return false
-end
-
-function Tool.onMouseUp(x,y)
-    if not Tool.active or not Tool.startSq then return false end
-    local cur = safeMouseSquare()
-    if not cur then return false end
-    Tool.rect = makeRect(Tool.startSq, cur)
-    addHighlight(Tool.rect)
-    if Tool.kind == "chop" then
-        AutoChopTask.chopRect = Tool.rect
-        getP():Say("Chop area set.")
-    else
-        AutoChopTask.gatherRect = Tool.rect
-        getP():Say("Gather area set.")
-    end
-    Tool.active, Tool.kind, Tool.startSq = false, nil, nil
-    return false
-end
+  end,
+  Clear = clearHighlight
+}
 
 Events.OnMouseDown.Add(Tool.onMouseDown)
 Events.OnMouseMove.Add(Tool.onMouseMove)
 Events.OnMouseUp.Add(Tool.onMouseUp)
+

--- a/42/media/lua/client/AutoChopContext.lua
+++ b/42/media/lua/client/AutoChopContext.lua
@@ -1,124 +1,82 @@
-
 -- AutoChopContext.lua: right-click menu for AutoForester (B42)
 
-require "AutoChopTask"
+local AFCore = require "AutoForester_Core"
 require "AF_SelectArea"
 
+local function hasAxe(p)
+  local function isAxeItem(it)
+    if not it then return false end
+    local ft = it:getFullType()
+    return ft == "Base.Axe" or ft == "Base.HandAxe" or ft == "Base.StoneAxe" or it:hasTag("Axe")
+  end
+  local prim, sec = p:getPrimaryHandItem(), p:getSecondaryHandItem()
+  return isAxeItem(prim) or isAxeItem(sec)
+end
+
 local function getSafeSquare(playerIndex, worldObjects)
-    local ms = _G.getMouseSquare
-    local sq = (type(ms)=="function") and ms() or nil
-    if sq and sq.getX then return sq end
+  local ms = _G.getMouseSquare
+  local sq = (type(ms) == "function") and ms() or nil
+  if sq and sq.getX then return sq end
 
-    if worldObjects then
-        local first = (worldObjects.get and worldObjects:get(0)) or worldObjects[1]
-        if first then
-            if first.getSquare then
-                local s = first:getSquare()
-                if s then return s end
-            elseif first.getX then
-                return first -- it's already a square
-            end
-        end
+  if worldObjects then
+    local first = (worldObjects.get and worldObjects:get(0)) or worldObjects[1]
+    if first then
+      if first.getSquare then
+        local s = first:getSquare()
+        if s then return s end
+      elseif first.getX then
+        return first
+      end
     end
+  end
 
-    local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
-    return p and p:getCurrentSquare() or nil
+  local p = getSpecificPlayer and getSpecificPlayer(playerIndex or 0)
+  return p and p:getCurrentSquare() or nil
 end
 
 local function onFillWorld(playerIndex, context, worldObjects, test)
-    if test then return end
-    local player = getSpecificPlayer(playerIndex or 0)
-    if not player or player:isDead() then return end
+  if test then return end
+  local player = getSpecificPlayer(playerIndex or 0)
+  if not player or player:isDead() then return end
 
-    context:addOption("AutoForester: Debug (hook loaded)", nil, function()
-        player:Say("Hook OK")
+  local sq = getSafeSquare(playerIndex, worldObjects)
+
+  context:addOption("Designate Log Stockpile Here", sq, function(targetSq)
+    targetSq = targetSq or getSafeSquare(playerIndex, worldObjects)
+    if targetSq then
+      AFCore.setStockpile(targetSq)
+      player:Say("Stockpile set.")
+    end
+  end)
+
+  context:addOption("Cancel AutoForester Job", nil, function()
+    AF_SelectArea.Clear()
+    AFCore.cancel()
+    player:Say("Canceled.")
+  end)
+
+  context:addOption("AF: Dump State (debug)", nil, function()
+    player:Say(string.format("AF phase=%s trees=%d idle=%d", tostring(AFCore.phase), #(AFCore.trees or {}), AFCore.idleTicks or 0))
+  end)
+
+  context:addOption("Chop Area: Set Corner", nil, function()
+    AF_SelectArea.Start("chop")
+  end)
+
+  context:addOption("Gather Area: Set Corner", nil, function()
+    AF_SelectArea.Start("gather")
+  end)
+
+  if not hasAxe(player) then
+    context:addOption("Auto-Chop Trees (radius 12)", nil, function()
+      player:Say("Equip an axe to use this.")
+    end):setTooltip(getText("Tooltip_RequireAxe"))
+  else
+    context:addOption("Auto-Chop Trees (radius 12)", nil, function()
+      AFCore.startJob_playerRadius(player, 12)
     end)
-
-    local sq = getSafeSquare(playerIndex, worldObjects)
-
-    -- Set stockpile
-    context:addOption("Designate Log Stockpile Here", sq, function(targetSq)
-        targetSq = targetSq or getSafeSquare(playerIndex, worldObjects)
-        local container = nil
-        if targetSq then
-            local objs = targetSq:getObjects()
-            if objs then
-                for i=0, objs:size()-1 do
-                    local obj = objs:get(i)
-                    if obj and obj.getContainer and obj:getContainer() then
-                        container = obj:getContainer()
-                        break
-                    end
-                end
-            end
-            AutoChopTask.setDropAt(targetSq, container)
-            if container then player:Say("Stockpile set (container).") else player:Say("Stockpile set (ground).") end
-        end
-    end)
-
-    context:addOption("Cancel AutoForester Job", nil, function()
-        if AutoChopTask and AutoChopTask.cancel then AutoChopTask.cancel("user cancel") end
-        player:Say("Canceled.")
-    end)
-
-    context:addOption("AF: Dump State (debug)", nil, function()
-        local p = getSpecificPlayer(playerIndex)
-        local q = ISTimedActionQueue.getTimedActionQueue(p)
-        p:Say(string.format("AF phase=%s active=%s queue=%d trees=%d idle=%d",
-            tostring(AutoChopTask.phase),
-            tostring(AutoChopTask.active),
-            (q and q:size() or 0),
-            (AutoChopTask.trees and #AutoChopTask.trees or 0),
-            AutoChopTask.idleTicks))
-    end)
-
-    context:addOption("Select Chop Area (drag)", nil, function()
-        AF_SelectArea.begin("chop")
-    end)
-
-    context:addOption("Select Gather Area (drag)", nil, function()
-        AF_SelectArea.begin("gather")
-    end)
-
-    -- Auto chop
-    local txt = string.format("Auto-Chop Trees (radius %d)", AutoChopTask.RADIUS)
-    context:addOption(txt, sq, function(targetSq)
-        targetSq = targetSq or getSafeSquare(playerIndex, worldObjects)
-        local p = getSpecificPlayer(playerIndex)
-        local function isAxe(it)
-            if not it then return false end
-            local cats = it:getCategories()
-            if cats then for i=0,cats:size()-1 do if tostring(cats:get(i))=="Axe" then return true end end end
-            return (it:getType() or ""):lower():find("axe") ~= nil
-        end
-
-        local primary = p:getPrimaryHandItem()
-        if not isAxe(primary) then
-            -- auto-equip best axe from inventory
-            local inv, best, bestC = p:getInventory(), nil, -1
-            local arr = inv and inv:getItems()
-            if arr then
-                for i=0, arr:size()-1 do
-                    local it = arr:get(i)
-                    if isAxe(it) then
-                        local c = it:getCondition() or 0
-                        if c > bestC then best, bestC = it, c end
-                    end
-                end
-            end
-            if best then
-                ISTimedActionQueue.add(ISEquipWeaponAction:new(p, best, 50, true, true))
-                p:Say("Equipping axe…")
-            else
-                p:Say("I need an axe.")
-                return
-            end
-        end
-        AutoChopTask.start(p, targetSq)
-    end)
+  end
 end
 
 Events.OnFillWorldObjectContextMenu.Add(onFillWorld)
-Events.OnTick.Add(function() 
-    if AutoChopTask and AutoChopTask.update then AutoChopTask.update() end
-end)
+


### PR DESCRIPTION
## Summary
- Rewrote area selection tool to safely highlight tiles without color calls and expose simple start/clear API
- Added wood-handling helpers and phased chopping/gathering logic with drop-on-ground behavior
- Streamlined context menu with axe checks, cancel option, and new area-selection commands

## Testing
- `luac -p 42/media/lua/client/AF_SelectArea.lua`
- `luac -p 42/media/lua/client/AutoForester_Core.lua`
- `luac -p 42/media/lua/client/AutoChopContext.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a50dfc955c832e8865eb53c5e12a28