### PR TITLE
Refactor area selection and auto-chop workflow

### DIFF
--- a/42/media/lua/client/AF_DropNowAction.lua
+++ b/42/media/lua/client/AF_DropNowAction.lua
@@ -1,0 +1,22 @@
+require "TimedActions/ISBaseTimedAction"
+
+AF_DropNowAction = ISBaseTimedAction:derive("AF_DropNowAction")
+
+function AF_DropNowAction:isValid() return true end
+function AF_DropNowAction:update() end
+function AF_DropNowAction:start() end
+function AF_DropNowAction:stop() ISBaseTimedAction.stop(self) end
+function AF_DropNowAction:perform()
+  if AutoChopTask and AutoChopTask.dropWoodNow then
+    AutoChopTask.dropWoodNow(self.character)
+  end
+  ISBaseTimedAction.perform(self)
+end
+
+function AF_DropNowAction:new(character)
+  local o = ISBaseTimedAction.new(self, character)
+  o.maxTime = 1
+  return o
+end
+
+return AF_DropNowAction

--- a/42/media/lua/client/AF_HaulWoodToPileAction.lua
+++ b/42/media/lua/client/AF_HaulWoodToPileAction.lua
@@ -1,0 +1,28 @@
+require "TimedActions/ISBaseTimedAction"
+require "TimedActions/ISTimedActionQueue"
+require "TimedActions/ISWalkToTimedAction"
+
+AF_HaulWoodToPileAction = ISBaseTimedAction:derive("AF_HaulWoodToPileAction")
+
+function AF_HaulWoodToPileAction:isValid() return true end
+function AF_HaulWoodToPileAction:update() end
+function AF_HaulWoodToPileAction:start() end
+function AF_HaulWoodToPileAction:stop() ISBaseTimedAction.stop(self) end
+function AF_HaulWoodToPileAction:perform()
+  local p = self.character
+  local pileSq = self.pileSq
+  if p and pileSq then
+    ISTimedActionQueue.add(ISWalkToTimedAction:new(p, pileSq))
+    ISTimedActionQueue.add(AF_DropNowAction:new(p))
+  end
+  ISBaseTimedAction.perform(self)
+end
+
+function AF_HaulWoodToPileAction:new(character, pileSq)
+  local o = ISBaseTimedAction.new(self, character)
+  o.pileSq = pileSq
+  o.maxTime = 1
+  return o
+end
+
+return AF_HaulWoodToPileAction

--- a/42/media/lua/client/AF_SweepWoodAction.lua
+++ b/42/media/lua/client/AF_SweepWoodAction.lua
@@ -1,0 +1,44 @@
+require "TimedActions/ISBaseTimedAction"
+require "TimedActions/ISTimedActionQueue"
+require "TimedActions/ISPickupWorldItemAction"
+
+AF_SweepWoodAction = ISBaseTimedAction:derive("AF_SweepWoodAction")
+
+function AF_SweepWoodAction:isValid() return true end
+function AF_SweepWoodAction:update() end
+function AF_SweepWoodAction:start() end
+function AF_SweepWoodAction:stop() ISBaseTimedAction.stop(self) end
+function AF_SweepWoodAction:perform()
+  local p = self.character
+  local rect = self.areaRect
+  if p and rect and AutoChopTask and AutoChopTask.isWood then
+    local cell = getCell()
+    for x = rect[1], rect[3] do
+      for y = rect[2], rect[4] do
+        local sq = cell:getGridSquare(x, y, rect[5] or 0)
+        if sq then
+          local wios = sq:getWorldObjects()
+          if wios then
+            for i = 0, wios:size()-1 do
+              local wio = wios:get(i)
+              local it = wio and wio:getItem()
+              if it and AutoChopTask.isWood(it) then
+                ISTimedActionQueue.add(ISPickupWorldItemAction:new(p, it, x, y, sq:getZ()))
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+  ISBaseTimedAction.perform(self)
+end
+
+function AF_SweepWoodAction:new(character, areaRect)
+  local o = ISBaseTimedAction.new(self, character)
+  o.areaRect = areaRect
+  o.maxTime = 1
+  return o
+end
+
+return AF_SweepWoodAction


### PR DESCRIPTION
## Summary
- Reworked AF_SelectArea tool for reliable drag selection and highlighting.
- Added robust axe detection and guarded context options for Auto-Chop.
- Introduced phased AutoForester core with immediate log drops and post-chop gathering/hauling.
- Implemented helper timed actions for instant dropping, sweeping, and hauling wood.

## Testing
- `luac -p 42/media/lua/client/AF_SelectArea.lua 42/media/lua/client/AutoChopContext.lua 42/media/lua/client/AutoForester_Core.lua 42/media/lua/client/AF_DropNowAction.lua 42/media/lua/client/AF_SweepWoodAction.lua 42/media/lua/client/AF_HaulWoodToPileAction.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a516cb0740832e9c540fdc4a8d9565