### PR TITLE
Add logging utilities and player checks

### DIFF
--- a/42/media/lua/client/AF_SelectArea.lua
+++ b/42/media/lua/client/AF_SelectArea.lua
@@ -1,5 +1,6 @@
 -- AF_SelectArea.lua  (B42 safe)
 local AutoChopTask = AutoChopTask or {} -- forward ref if file order loads this first
+AF_SelectArea_EventsHooked = AF_SelectArea_EventsHooked or false
 
 local Tool = {
   active      = false,
@@ -106,16 +107,19 @@ function Tool.onMouseUp(x,y)
     AutoChopTask.gatherRect = Tool.rect
     if p and p.Say then p:Say("Gather area set.") end
   end
-
+  AF_DumpState("areaSet:"..Tool.kind)
   Tool.cancel()
   return true
 end
 
 AF_SelectArea = Tool
-if Events and Events.OnMouseDown and Events.OnMouseDown.Add then
-  Events.OnMouseDown.Add(Tool.onMouseDown)
-  Events.OnMouseMove.Add(Tool.onMouseMove)
-  Events.OnMouseUp.Add(Tool.onMouseUp)
+
+if not AF_SelectArea_EventsHooked then
+  Events.OnMouseDown.Add(AF_SelectArea.onMouseDown)
+  Events.OnMouseMove.Add(AF_SelectArea.onMouseMove)
+  Events.OnMouseUp.Add(AF_SelectArea.onMouseUp)
+  AF_SelectArea_EventsHooked = true
+  AFLOG("SelectArea: mouse events hooked")
 end
 return Tool
 

--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -1,4 +1,5 @@
 local AFCore = require("AutoForester_Core")
+local AF_SelectArea = require("AF_SelectArea")
 
 local getP = AFCore.getP
 
@@ -26,6 +27,16 @@ local function addMenu(pi, context, wos, test)
   if test then return end
   local sq = getSafeSquare(pi, wos)
 
+  context:addOption("Chop Area: Set Corner", nil, function()
+    AF_SelectArea.start("chop")
+    AFLOG("SelectArea: start 'chop'")
+  end)
+
+  context:addOption("Gather Area: Set Corner", nil, function()
+    AF_SelectArea.start("gather")
+    AFLOG("SelectArea: start 'gather'")
+  end)
+
   context:addOption("Designate Wood Pile Here", sq, function(targetSq)
     local c = AFCore; if not c then say(pi,"AutoForester core didn’t load. Check console."); return end
     targetSq = targetSq or getSafeSquare(pi, wos)
@@ -34,8 +45,11 @@ local function addMenu(pi, context, wos, test)
 
   context:addOption("Auto-Chop Nearby Trees", sq, function()
     local c = AFCore; if not c then say(pi,"AutoForester core didn’t load. Check console."); return end
-    local p = getP and getP(pi or 0); if not p then say(pi,"No player"); return end
-    c.startJob_playerRadius(p, 12)
+    c.startJob(pi)
+  end)
+
+  context:addOption("AF: Dump State (debug)", nil, function()
+    AF_DumpState("menu")
   end)
 
   local c = AFCore


### PR DESCRIPTION
## Summary
- Add reusable `AFLOG` and `AF_DumpState` utilities
- Assert player presence in queue helpers and drop wood routine
- Provide `startJob` entry, area-selection options, and debug state menu
- Wire selection tool mouse events once with logging

## Testing
- `luac -p 42/media/lua/client/AutoForester_Core.lua 42/media/lua/client/AutoForester_Context.lua 42/media/lua/client/AF_SelectArea.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a51eb6a018832ebb84b5d165e01108