### PR TITLE
Add robust selection adapters and fix context menu crash

### DIFF
--- a/42/media/lua/client/AF_SelectAdapter.lua
+++ b/42/media/lua/client/AF_SelectAdapter.lua
@@ -1,45 +1,23 @@
 -- AF_SelectAdapter.lua
 AF_Select = AF_Select or {}
 
-local function mouseSquareOrNil(p)
-  local z = p:getZ() or 0
-  local mx,my = getMouseXScaled(), getMouseYScaled()
-  local wx = ISCoordConversion.ToWorldX(mx,my,z)
-  local wy = ISCoordConversion.ToWorldY(mx,my,z)
-  return getCell():getGridSquare(math.floor(wx), math.floor(wy), z)
-end
+local function hasJB() return type(JB_ASSUtils) == "table" end
 
--- Normalize JB_ASSUtils selectedArea to our rect record
-local function areaToRect(a)
-  -- JB returns: { squares={}, minX, maxX, minY, maxY, z, ... }
-  if not a or not a.minX then return nil end
-  return { a.minX, a.minY, a.maxX, a.maxY, a.z or 0 }
-end
-
--- === Public: pick one square (for wood pile) ================================
-function AF_Select.pickSquare(worldObjects, playerObj, callback)
-  if JB_ASSUtils then
-    -- args: (worldObjects, playerObj, callback, ...optionalArgs)
-    return JB_ASSUtils.SelectSingleSquare(worldObjects, playerObj, function(selectedSquare)
-      if callback then callback(selectedSquare) end
-    end)
+-- Pick a single square (used by “Designate wood pile”)
+function AF_Select.pickSquare(worldObjects, p, cb)
+  if hasJB() and JB_ASSUtils.SelectSingleSquare then
+    return JB_ASSUtils.SelectSingleSquare(worldObjects, p, cb)
   end
-  -- Fallback: immediate mouse square
-  local sq = mouseSquareOrNil(playerObj)
-  if callback then callback(sq) end
+  -- Fallback: use current mouse square immediately
+  local sq = AF_getContextSquare(worldObjects)
+  cb(sq, p)
 end
 
--- === Public: drag area for "chop" / "gather" =============================
-function AF_Select.pickArea(worldObjects, playerObj, callback, kindLabel)
-  if JB_ASSUtils then
-    return JB_ASSUtils.SelectArea(worldObjects, playerObj, function(selectedArea)
-      if callback then callback(areaToRect(selectedArea), selectedArea) end
-    end)
+-- Pick an area (drag & release). If JB exists, delegate; else fallback tool.
+function AF_Select.pickArea(worldObjects, p, cb, kind)
+  if hasJB() and JB_ASSUtils.SelectArea then
+    return JB_ASSUtils.SelectArea(worldObjects, p, cb, kind)
   end
-  -- Fallback: single click → tiny 1x1 rect
-  local sq = mouseSquareOrNil(playerObj)
-  local rect = sq and {sq:getX(), sq:getY(), sq:getX(), sq:getY(), sq:getZ()} or nil
-  if callback then callback(rect, { squares = sq and {sq} or {}, z = sq and sq:getZ() or 0 }) end
+  require "AF_SelectArea"      -- ensures fallback exists
+  AF_SelectArea.start(kind or "generic", function(rect, area) cb(rect, area) end)
 end
-
-return AF_Select

--- a/42/media/lua/client/AF_SelectArea.lua
+++ b/42/media/lua/client/AF_SelectArea.lua
@@ -1,0 +1,67 @@
+-- AF_SelectArea.lua  (fallback tool used when JB_ASSUtils isn't present)
+require "ISCoordConversion"
+
+AF_SelectArea = AF_SelectArea or {}
+local Tool = { active=false, kind=nil, startSq=nil, rect=nil, hi={} }
+local function clear()
+  for _,sq in ipairs(Tool.hi) do if sq.setHighlighted then sq:setHighlighted(false) end end
+  Tool.hi = {}
+end
+local function getMouseSq()
+  local p = getSpecificPlayer(0); if not p then return nil end
+  local mx,my = getMouseXScaled(), getMouseYScaled()
+  local wx = ISCoordConversion.ToWorldX(mx,my,0)
+  local wy = ISCoordConversion.ToWorldY(mx,my,0)
+  local cell = getCell(); if not cell then return nil end
+  return cell:getGridSquare(math.floor(wx), math.floor(wy), p:getZ() or 0)
+end
+local function norm(a,b)
+  local x1 = math.min(a:getX(), b:getX()); local y1 = math.min(a:getY(), b:getY())
+  local x2 = math.max(a:getX(), b:getX()); local y2 = math.max(a:getY(), b:getY())
+  local z = a:getZ()
+  return {x1,y1,x2,y2,z}
+end
+local function hiRect(r)
+  clear(); if not r then return end
+  local cell = getCell(); if not cell then return end
+  local x1,y1,x2,y2,z = r[1],r[2],r[3],r[4],r[5] or 0
+  for y=y1,y2 do for x=x1,x2 do
+    local sq = cell:getGridSquare(x,y,z)
+    if sq and sq.setHighlighted then
+      sq:setHighlighted(true)
+      if sq.setHighlightColor then sq:setHighlightColor(0,1,0,0.6) end
+      table.insert(Tool.hi, sq)
+    end
+  end end
+end
+
+function AF_SelectArea.start(kind, onDone)
+  Tool.active = true; Tool.kind = kind; Tool.startSq = getMouseSq(); Tool.rect=nil
+  Tool._cb = onDone
+  Events.OnMouseMoveDel.Add(AF_SelectArea.onMouseMove)
+  Events.OnMouseUp.Add(AF_SelectArea.onMouseUp)
+end
+
+function AF_SelectArea.onMouseMove(dx,dy)
+  if not Tool.active or not Tool.startSq then return end
+  local cur = getMouseSq(); if not cur then return end
+  Tool.rect = norm(Tool.startSq, cur)
+  hiRect(Tool.rect)
+end
+
+function AF_SelectArea.onMouseUp(x,y)
+  if not Tool.active then return end
+  local cur = getMouseSq()
+  Events.OnMouseMoveDel.Remove(AF_SelectArea.onMouseMove)
+  Events.OnMouseUp.Remove(AF_SelectArea.onMouseUp)
+  Tool.active=false
+  if not cur or not Tool.startSq then clear(); if Tool._cb then Tool._cb(nil) end; return end
+  Tool.rect = norm(Tool.startSq, cur)
+  hiRect(Tool.rect)
+  if Tool._cb then
+    local r = Tool.rect
+    local area = { minX=r[1], maxX=r[3], minY=r[2], maxY=r[4], z=r[5] or 0,
+                   areaWidth=r[3]-r[1]+1, areaHeight=r[4]-r[2]+1, numSquares=(r[3]-r[1]+1)*(r[4]-r[2]+1) }
+    Tool._cb(r, area)
+  end
+end

--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -1,39 +1,46 @@
-require "AF_SelectAdapter"
+-- AutoForester_Context.lua
 require "AutoForester_Core"
-require "AutoChopTask"
-require "AutoForester_Debug"
+require "AF_SelectAdapter"
 
 local function addMenu(playerIndex, context, worldObjects, test)
   if test then return end
   local p = getSpecificPlayer(playerIndex or 0); if not p then return end
 
-  context:addOption("Designate Wood Pile Here", worldObjects, function()
-    AF_Select.pickSquare(worldObjects, p, function(sq)
-      if not sq then p:Say("No tile."); return end
+  -- Designate wood pile (uses selection adapter for a single square)
+  context:addOption("Designate Wood Pile Here", worldObjects, function(wos, pObj)
+    local pp = pObj or p
+    AF_Select.pickSquare(wos, pp, function(sq)
+      if not sq then SAY(pp,"No tile."); return end
       AFCore.setStockpile(sq)
-      p:Say("Wood pile set.")
+      SAY(pp,"Wood pile set.")
     end)
-  end)
+  end, p)
 
-  context:addOption("Chop Area: Drag & Release", worldObjects, function()
-    AF_Select.pickArea(worldObjects, p, function(rect, area)
-      if not rect then p:Say("No area."); return end
-      AutoChopTask.chopRect = rect
-      p:Say(("Chop area: %dx%d tiles."):format(area.areaWidth or (rect[3]-rect[1]+1), area.areaHeight or (rect[4]-rect[2]+1)))
+  -- Drag & release areas
+  context:addOption("Chop Area: Drag & Release", worldObjects, function(wos, pObj)
+    local pp = pObj or p
+    AF_Select.pickArea(wos, pp, function(rect, area)
+      if not rect then SAY(pp,"No area."); return end
+      AFCore.chopRect = rect
+      SAY(pp, ("Chop area: %dx%d"):format(area.areaWidth, area.areaHeight))
     end, "chop")
-  end)
+  end, p)
 
-  context:addOption("Gather Area: Drag & Release", worldObjects, function()
-    AF_Select.pickArea(worldObjects, p, function(rect, area)
-      if not rect then p:Say("No area."); return end
-      AutoChopTask.gatherRect = rect
-      p:Say(("Gather area: %dx%d tiles."):format(area.areaWidth or (rect[3]-rect[1]+1), area.areaHeight or (rect[4]-rect[2]+1)))
+  context:addOption("Gather Area: Drag & Release", worldObjects, function(wos, pObj)
+    local pp = pObj or p
+    AF_Select.pickArea(wos, pp, function(rect, area)
+      if not rect then SAY(pp,"No area."); return end
+      AFCore.gatherRect = rect
+      SAY(pp, ("Gather area: %dx%d"):format(area.areaWidth, area.areaHeight))
     end, "gather")
-  end)
+  end, p)
 
-  context:addOption("Start AutoForester (Area)", worldObjects, function()
-    AutoChopTask.startAreaJob(p)
-  end)
+  context:addOption("Start AutoForester (Area)", worldObjects, function(wos, pObj)
+    local pp = pObj or p
+    AFCore.startAreaJob(pp, AFCore.chopRect, AFCore.gatherRect)
+  end, p)
 end
 
+-- Make sure we only ever have one hook alive
+Events.OnFillWorldObjectContextMenu.Remove(addMenu)
 Events.OnFillWorldObjectContextMenu.Add(addMenu)

--- a/42/media/lua/client/AutoForester_Core.lua
+++ b/42/media/lua/client/AutoForester_Core.lua
@@ -1,79 +1,147 @@
 -- AutoForester_Core.lua
-require "AutoForester_Debug"
-
--- Optional JB_ASSUtils soft dependency
-local ok, lib = pcall(require, "JB_ASSUtils")
-AF_HasASS = ok and type(lib) == "table"
-JB_ASSUtils = ok and lib or nil
-
+require "ISCoordConversion"
 AFCore = AFCore or {}
 
-function AFCore.squareHasTree(sq)
+-- --------- debug toggle ----------
+AF_DEBUG = AF_DEBUG ~= false
+local function DBG(tag, ...) if AF_DEBUG then print("[AF]["..tostring(tag).."]", ...) end end
+local function SAY(p, msg) if p and p.Say then p:Say(msg) end end
+
+-- --------- soft-detect JB selector ----------
+-- DO NOT require by name; workshop name can vary. The JB lib usually exposes a global table.
+local hasJB = type(JB_ASSUtils) == "table"
+
+-- --------- player / square helpers ----------
+function AF_getPlayer(maybePi)
+  local idx = 0
+  if type(maybePi) == "number" then idx = maybePi
+  elseif type(maybePi) == "table" and maybePi.getPlayerNum then idx = maybePi:getPlayerNum()
+  end
+  local p = getSpecificPlayer(idx)
+  if p and p:isAlive() then return p, idx end
+  DBG("getPlayer","failed idx",idx)
+  return nil, idx
+end
+
+-- WorldObjects → a sensible IsoGridSquare, else mouse square
+function AF_getContextSquare(worldobjects)
+  -- from worldobjects first
+  if worldobjects then
+    for i=1,#worldobjects do
+      local o = worldobjects[i]
+      if o and o.getSquare then
+        local sq = o:getSquare()
+        if sq then return sq end
+      end
+    end
+  end
+  -- mouse fallback
+  local p = getSpecificPlayer(0)
+  local z = (p and p:getZ()) or 0
+  local mx, my = getMouseXScaled(), getMouseYScaled()
+  local wx = ISCoordConversion.ToWorldX(mx,my,0)
+  local wy = ISCoordConversion.ToWorldY(mx,my,0)
+  local cell = getCell(); if not cell then return nil end
+  return cell:getGridSquare(math.floor(wx), math.floor(wy), z)
+end
+
+-- --------- stockpile marker ----------
+AFCore.pileSq = AFCore.pileSq or nil
+
+function AFCore.setStockpile(sq)
+  AFCore.pileSq = sq
+  if sq and sq.setHighlighted then
+    sq:setHighlighted(true)
+    if sq.setHighlightColor then sq:setHighlightColor(0.95,0.85,0.20) end
+  end
+  DBG("PILE","set", sq and sq:getX(), sq and sq:getY(), sq and sq:getZ())
+end
+
+function AFCore.clearStockpile()
+  if AFCore.pileSq and AFCore.pileSq.setHighlighted then AFCore.pileSq:setHighlighted(false) end
+  AFCore.pileSq = nil
+end
+
+function AFCore.getStockpile() return AFCore.pileSq end
+
+-- --------- trees ----------
+local function squareHasTree(sq)
   if not sq then return false end
   if sq.HasTree and sq:HasTree() then return true end
-  local objs = sq:getObjects()
-  for i=0,(objs and objs:size() or 0)-1 do
-    if instanceof(objs:get(i), "IsoTree") then return true end
+  local os = sq:getObjects()
+  for i=0,(os and os:size() or 0)-1 do
+    if instanceof(os:get(i), "IsoTree") then return true end
   end
   return false
 end
 
-function AFCore.getTreeFromSquare(sq)
+local function getTreeFromSquare(sq)
   if not sq then return nil end
   if sq.getTree and sq:HasTree() then return sq:getTree() end
-  local objs = sq:getObjects()
-  for i=0,(objs and objs:size() or 0)-1 do
-    local o = objs:get(i)
+  local os = sq:getObjects()
+  for i=0,(os and os:size() or 0)-1 do
+    local o = os:get(i)
     if instanceof(o, "IsoTree") then return o end
   end
   return nil
 end
 
-function AFCore.treesInRect(rect)
-  local res = {}
-  if not rect then return res end
-  local x1,y1,x2,y2,z = rect[1],rect[2],rect[3],rect[4],rect[5] or 0
-  local cell = getCell(); if not cell then return res end
-  for y=y1,y2 do
-    for x=x1,x2 do
-      local sq = cell:getGridSquare(x,y,z)
-      if AFCore.squareHasTree(sq) then table.insert(res, sq) end
-    end
-  end
+function AFCore.treesInRect(r)
+  local res, cell = {}, getCell(); if not (r and cell) then return res end
+  local x1,y1,x2,y2,z = r[1],r[2],r[3],r[4],r[5] or 0
+  for y=y1,y2 do for x=x1,x2 do
+    local sq = cell:getGridSquare(x,y,z)
+    if squareHasTree(sq) then table.insert(res, sq) end
+  end end
+  DBG("TREES","in rect", #res)
   return res
 end
 
-function AFCore.queueChops(player, squares)
+-- Queue chops using vanilla actions (no custom TA required to validate flow)
+function AFCore.queueChops(p, squares)
   local n=0
   for _,sq in ipairs(squares) do
-    local tree = AFCore.getTreeFromSquare(sq)
+    local tree = getTreeFromSquare(sq)
     if tree then
-      ISTimedActionQueue.add(ISWalkToTimedAction:new(player, sq))
-      ISWorldObjectContextMenu.doChopTree(player, tree)
+      ISTimedActionQueue.add(ISWalkToTimedAction:new(p, sq))
+      -- vanilla helper schedules swing(s):
+      ISWorldObjectContextMenu.doChopTree(p, tree)
       n = n + 1
     end
   end
   return n
 end
 
-function AFCore.dropTreeLootNow(player)
-  local inv = player:getInventory()
+-- Immediately drop heavy loot after some chops so we don’t stall on weight
+function AFCore.dropTreeLootNow(p)
+  local inv = p and p:getInventory(); if not inv then return end
   local types = { "Base.Log", "Base.TreeBranch", "Base.LargeBranch", "Base.Twigs", "Base.Sapling" }
   for _,full in ipairs(types) do
     local items = inv:getItemsFromFullType(full)
     if items then
-      for i=0, items:size()-1 do
-        ISTimedActionQueue.add(ISDropItemAction:new(player, items:get(i)))
+      for i=0,items:size()-1 do
+        ISTimedActionQueue.add(ISDropItemAction:new(p, items:get(i)))
       end
     end
   end
 end
 
-function AFCore.setStockpile(sq)
-  AFCore.pileSq = sq
-  if sq and sq.setHighlighted then
-    sq:setHighlighted(true); if sq.setHighlightColor then sq:setHighlightColor(0.95,0.85,0.2) end
-  end
-end
+-- --------- area job entry (chop only; sweep/haul can follow) ----------
+function AFCore.startAreaJob(pOrIndex, chopRect, gatherRect)
+  local p = AF_getPlayer(pOrIndex); if not p then return end
+  if not chopRect then SAY(p,"Set chop area first."); return end
+  if not AFCore.getStockpile() then SAY(p,"Designate wood pile first."); return end
 
-function AFCore.getStockpile() return AFCore.pileSq end
+  local list = AFCore.treesInRect(chopRect)
+  if #list == 0 then SAY(p,"No trees in chop area."); return end
+
+  local n = AFCore.queueChops(p, list)
+  -- yield + drop now
+  ISTimedActionQueue.add(ISBaseTimedAction:new(p)) -- micro-yield
+  ISTimedActionQueue.add(ISBaseTimedAction:new(p)) -- micro-yield
+  ISTimedActionQueue.add(ISBaseTimedAction:new(p)) -- keep simple
+  AFCore.dropTreeLootNow(p)
+
+  SAY(p, ("Queued %d tree(s)."):format(n))
+  DBG("JOB","queued", n)
+end


### PR DESCRIPTION
## Summary
- refactor AutoForester core to handle player lookup, stockpile marking, tree queuing and heavy loot drops
- add JB-aware selection adapter with safe fallback area tool
- update world context menu to use new selection helpers and ensure single hook

## Testing
- `luac -p 42/media/lua/client/AutoForester_Core.lua 42/media/lua/client/AF_SelectAdapter.lua 42/media/lua/client/AF_SelectArea.lua 42/media/lua/client/AutoForester_Context.lua`

------
https://chatgpt.com/codex/tasks/task_e_68a54929d680832e96060b4bd0f257f7