### PR TITLE
Refactor context menu and selection with safe tree operations

### DIFF
--- a/42/media/lua/client/AF_SelectArea.lua
+++ b/42/media/lua/client/AF_SelectArea.lua
@@ -1,67 +1,78 @@
--- AF_SelectArea.lua  (fallback tool used when JB_ASSUtils isn't present)
+-- AF_SelectArea.lua (fallback selector)
 require "ISCoordConversion"
 
 AF_SelectArea = AF_SelectArea or {}
-local Tool = { active=false, kind=nil, startSq=nil, rect=nil, hi={} }
+local Tool = { tag=nil, dragging=false, ax=0, ay=0, z=0, rect=nil, hi={} }
+
 local function clear()
   for _,sq in ipairs(Tool.hi) do if sq.setHighlighted then sq:setHighlighted(false) end end
   Tool.hi = {}
 end
-local function getMouseSq()
-  local p = getSpecificPlayer(0); if not p then return nil end
+
+local function mouseSq()
   local mx,my = getMouseXScaled(), getMouseYScaled()
   local wx = ISCoordConversion.ToWorldX(mx,my,0)
   local wy = ISCoordConversion.ToWorldY(mx,my,0)
-  local cell = getCell(); if not cell then return nil end
-  return cell:getGridSquare(math.floor(wx), math.floor(wy), p:getZ() or 0)
+  local p = getSpecificPlayer(0)
+  local z = p and p:getZ() or 0
+  return math.floor(wx), math.floor(wy), z
 end
-local function norm(a,b)
-  local x1 = math.min(a:getX(), b:getX()); local y1 = math.min(a:getY(), b:getY())
-  local x2 = math.max(a:getX(), b:getX()); local y2 = math.max(a:getY(), b:getY())
-  local z = a:getZ()
-  return {x1,y1,x2,y2,z}
-end
+
 local function hiRect(r)
   clear(); if not r then return end
   local cell = getCell(); if not cell then return end
   local x1,y1,x2,y2,z = r[1],r[2],r[3],r[4],r[5] or 0
   for y=y1,y2 do for x=x1,x2 do
-    local sq = cell:getGridSquare(x,y,z)
-    if sq and sq.setHighlighted then
-      sq:setHighlighted(true)
-      if sq.setHighlightColor then sq:setHighlightColor(0,1,0,0.6) end
-      table.insert(Tool.hi, sq)
-    end
+      local sq = cell:getGridSquare(x,y,z)
+      if sq and sq.setHighlighted then
+        sq:setHighlighted(true)
+        if sq.setHighlightColor then sq:setHighlightColor(0,1,0,0.6) end
+        table.insert(Tool.hi, sq)
+      end
   end end
 end
 
-function AF_SelectArea.start(kind, onDone)
-  Tool.active = true; Tool.kind = kind; Tool.startSq = getMouseSq(); Tool.rect=nil
-  Tool._cb = onDone
-  Events.OnMouseMoveDel.Add(AF_SelectArea.onMouseMove)
+function AF_SelectArea.start(tag)
+  Tool.tag = tag; Tool.dragging=false; Tool.rect=nil
+  Events.OnMouseDown.Add(AF_SelectArea.onMouseDown)
+  Events.OnMouseMove.Add(AF_SelectArea.onMouseMove)
   Events.OnMouseUp.Add(AF_SelectArea.onMouseUp)
 end
 
+function AF_SelectArea.stop()
+  Events.OnMouseDown.Remove(AF_SelectArea.onMouseDown)
+  Events.OnMouseMove.Remove(AF_SelectArea.onMouseMove)
+  Events.OnMouseUp.Remove(AF_SelectArea.onMouseUp)
+  Tool.dragging=false; Tool.rect=nil; clear()
+end
+
+function AF_SelectArea.onMouseDown(x,y)
+  Tool.ax,Tool.ay,Tool.z = mouseSq()
+  Tool.dragging=true
+end
+
 function AF_SelectArea.onMouseMove(dx,dy)
-  if not Tool.active or not Tool.startSq then return end
-  local cur = getMouseSq(); if not cur then return end
-  Tool.rect = norm(Tool.startSq, cur)
+  if not Tool.dragging then return end
+  local bx,by = mouseSq()
+  local x1 = math.min(Tool.ax,bx)
+  local y1 = math.min(Tool.ay,by)
+  local x2 = math.max(Tool.ax,bx)
+  local y2 = math.max(Tool.ay,by)
+  Tool.rect = {x1,y1,x2,y2,Tool.z}
   hiRect(Tool.rect)
 end
 
 function AF_SelectArea.onMouseUp(x,y)
-  if not Tool.active then return end
-  local cur = getMouseSq()
-  Events.OnMouseMoveDel.Remove(AF_SelectArea.onMouseMove)
-  Events.OnMouseUp.Remove(AF_SelectArea.onMouseUp)
-  Tool.active=false
-  if not cur or not Tool.startSq then clear(); if Tool._cb then Tool._cb(nil) end; return end
-  Tool.rect = norm(Tool.startSq, cur)
-  hiRect(Tool.rect)
-  if Tool._cb then
-    local r = Tool.rect
-    local area = { minX=r[1], maxX=r[3], minY=r[2], maxY=r[4], z=r[5] or 0,
-                   areaWidth=r[3]-r[1]+1, areaHeight=r[4]-r[2]+1, numSquares=(r[3]-r[1]+1)*(r[4]-r[2]+1) }
-    Tool._cb(r, area)
+  AF_SelectArea.stop()
+  local r = Tool.rect
+  if AF_SelectArea.onDone then
+    if not r or r[3] < r[1] or r[4] < r[2] then
+      AF_SelectArea.onDone(nil)
+    else
+      local area = { minX=r[1], minY=r[2], maxX=r[3], maxY=r[4], z=r[5] or 0,
+                     areaWidth=r[3]-r[1]+1, areaHeight=r[4]-r[2]+1,
+                     numSquares=(r[3]-r[1]+1)*(r[4]-r[2]+1) }
+      AF_SelectArea.onDone(r, area)
+    end
   end
 end

--- a/42/media/lua/client/AutoChopTask.lua
+++ b/42/media/lua/client/AutoChopTask.lua
@@ -4,22 +4,19 @@ require "AF_Instant"
 
 AutoChopTask = AutoChopTask or { chopRect=nil, gatherRect=nil }
 
-function AutoChopTask.startAreaJob(player)
-  if not AutoChopTask.chopRect then player:Say("Set chop area first."); return end
-  if not AFCore.getStockpile() then player:Say("Designate wood pile first."); return end
-
+function AutoChopTask.startAreaJob(p)
+  if not AutoChopTask.chopRect then p:Say("Set chop area first."); return end
+  if not AFCore.getStockpile() then p:Say("Designate wood pile first."); return end
   local trees = AFCore.treesInRect(AutoChopTask.chopRect)
-  if #trees == 0 then player:Say("No trees in chop area."); return end
+  if #trees == 0 then p:Say("No trees in chop area."); return end
 
-  -- 1) Chop & drop heavy loot immediately after each chop batch
-  local n = AFCore.queueChops(player, trees)
-  ISTimedActionQueue.add(ISBaseTimedAction:new(player)) -- tiny yield
-  ISTimedActionQueue.add(AFInstant:new(player, function() AFCore.dropTreeLootNow(player) end))
-  player:Say(("Queued %d tree(s)."):format(n))
+  local n = AFCore.queueChops(p, trees)
+  ISTimedActionQueue.add(AFInstant:new(p, function()
+    AFCore.dropTreeLootNow(p)
+  end))
+  p:Say(("Queued %d tree(s)."):format(n))
 
-  -- 2) Sweep → haul (use gatherRect if set, else chopRect)
   local rect = AutoChopTask.gatherRect or AutoChopTask.chopRect
-  ISTimedActionQueue.add(AFInstant:new(player, function() player:Say("Gathering wood…") end))
-  AFSweep.enqueueSweep(player, rect)
-  AFSweep.enqueueHaulToPile(player, AFCore.getStockpile())
+  AFSweep.enqueueSweep(p, rect)
+  AFSweep.enqueueHaulToPile(p, AFCore.getStockpile())
 end

--- a/42/media/lua/client/AutoForester_Debug.lua
+++ b/42/media/lua/client/AutoForester_Debug.lua
@@ -1,16 +1,12 @@
--- AutoForester_Debug.lua
-AFDBG = { on = true }  -- flip to false to silence
-
-local prefix = "[AF] "
+AFDBG = { on = true, chat = true }
 
 function AFLOG(tag, ...)
-    if not AFDBG.on then return end
-    local msg = table.concat({ ... }, " ")
-    print(prefix .. tag .. "> " .. msg)
-    if getPlayer() then getPlayer():Say(tag .. ": " .. msg) end
+  if not AFDBG.on then return end
+  local parts = {}
+  for i=1,select("#", ...) do parts[i] = tostring(select(i, ...)) end
+  print(("[AF] %s: %s"):format(tag, table.concat(parts, " ")))
 end
 
 function AFSAY(p, msg)
-    if not p then return end
-    if AFDBG.on then p:Say(msg) end
+  if AFDBG.chat and p then p:Say(tostring(msg)) end
 end


### PR DESCRIPTION
## Summary
- Rewrote world context menu hook to register once and guard wood pile designation
- Added JB_ASSUtils-aware square/area selection adapters with fallback drag tool
- Replaced tree detection with IsoTree checks and queued chop→sweep→haul pipeline

## Testing
- `find 42/media/lua/client -name '*.lua' -print | while read f; do echo "$f"; luac -p "$f" || break; done`

------
https://chatgpt.com/codex/tasks/task_e_68a64cadc0f8832e9d64a58b31ce2b63