### PR TITLE
Harden square selection and highlight handling

### DIFF
--- a/42/media/lua/client/AF_SelectAdapter.lua
+++ b/42/media/lua/client/AF_SelectAdapter.lua
@@ -1,4 +1,6 @@
 -- AF_SelectAdapter.lua
+require "AutoForester_Debug"
+require "ISCoordConversion"
 local hasASS, ASS = pcall(require, "JB_ASSUtils")
 AF_Select = AF_Select or {}
 
@@ -11,6 +13,7 @@ function AF_Select.pickSquare(worldObjects, p, cb)
   local wx = ISCoordConversion.ToWorldX(mx,my,0)
   local wy = ISCoordConversion.ToWorldY(mx,my,0)
   local sq = getCell():getGridSquare(math.floor(wx), math.floor(wy), z)
+  AFLOG("select", "mouse=", mx, ",", my, " world=", wx, ",", wy, " z=", z, " sq=", tostring(sq))
   return cb(sq)
 end
 

--- a/42/media/lua/client/AF_SelectArea.lua
+++ b/42/media/lua/client/AF_SelectArea.lua
@@ -1,5 +1,6 @@
 -- AF_SelectArea.lua (fallback selector)
 require "ISCoordConversion"
+require "AutoForester_Debug"
 
 AF_SelectArea = AF_SelectArea or {}
 local Tool = { tag=nil, dragging=false, ax=0, ay=0, z=0, rect=nil, hi={} }
@@ -14,8 +15,10 @@ local function mouseSq()
   local wx = ISCoordConversion.ToWorldX(mx,my,0)
   local wy = ISCoordConversion.ToWorldY(mx,my,0)
   local p = getSpecificPlayer(0)
-  local z = p and p:getZ() or 0
-  return math.floor(wx), math.floor(wy), z
+  local z = (p and p:getZ()) or 0
+  local sq = getCell():getGridSquare(math.floor(wx), math.floor(wy), z)
+  AFLOG("select", "mouse=", mx, ",", my, " world=", wx, ",", wy, " z=", z, " sq=", tostring(sq))
+  return sq
 end
 
 local function hiRect(r)
@@ -47,13 +50,16 @@ function AF_SelectArea.stop()
 end
 
 function AF_SelectArea.onMouseDown(x,y)
-  Tool.ax,Tool.ay,Tool.z = mouseSq()
+  local sq = mouseSq()
+  if not sq then return end
+  Tool.ax,Tool.ay,Tool.z = sq:getX(), sq:getY(), sq:getZ()
   Tool.dragging=true
 end
 
 function AF_SelectArea.onMouseMove(dx,dy)
   if not Tool.dragging then return end
-  local bx,by = mouseSq()
+  local sq = mouseSq(); if not sq then return end
+  local bx,by = sq:getX(), sq:getY()
   local x1 = math.min(Tool.ax,bx)
   local y1 = math.min(Tool.ay,by)
   local x2 = math.max(Tool.ax,bx)

--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -11,11 +11,7 @@ local function addMenu(playerIndex, context, worldObjects, test)
   context:addOption("Designate Wood Pile Here", worldObjects, function()
     AF_Select.pickSquare(worldObjects, p, function(sq)
       if not sq then p:Say("No tile."); return end
-      AFCore.pileSq = sq
-      if sq.setHighlighted then
-        sq:setHighlighted(true)
-        if sq.setHighlightColor then sq:setHighlightColor(0.95,0.85,0.2) end
-      end
+      AFCore.setStockpile(sq)
       p:Say("Wood pile set.")
       AFLOG("pile", "sq=", tostring(sq), sq and (sq:getX()..","..sq:getY()..","..sq:getZ()) or "nil")
     end)

--- a/42/media/lua/client/AutoForester_Core.lua
+++ b/42/media/lua/client/AutoForester_Core.lua
@@ -48,7 +48,7 @@ function AFCore.setStockpile(sq)
   AFCore.pileSq = sq
   if sq and sq.setHighlighted then
     sq:setHighlighted(true)
-    if sq.setHighlightColor then sq:setHighlightColor(0.95,0.85,0.20) end
+    if sq.setHighlightColor then sq:setHighlightColor(0.9,0.8,0.2) end
   end
   AFLOG("PILE","set", sq and sq:getX(), sq and sq:getY(), sq and sq:getZ())
 end


### PR DESCRIPTION
## Summary
- guard square highlighting and route stockpile setting through `AFCore.setStockpile`
- resolve mouse coordinates to real grid squares for area selection
- add debug logging for mouse-to-world conversions

## Testing
- `luac -p 42/media/lua/client/AutoForester_Context.lua 42/media/lua/client/AutoForester_Core.lua 42/media/lua/client/AF_SelectArea.lua 42/media/lua/client/AF_SelectAdapter.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a654139090832e9ca9a05188a1c7b3