### PR TITLE
Refactor context and selection tools

### DIFF
--- a/42/media/lua/client/AutoChopTask.lua
+++ b/42/media/lua/client/AutoChopTask.lua
@@ -4,6 +4,18 @@ require "AF_Instant"
 
 AutoChopTask = AutoChopTask or { chopRect=nil, gatherRect=nil }
 
+local function dropTreeLootNow(p)
+  local inv = p:getInventory()
+  for _,full in ipairs({ "Base.Log","Base.TreeBranch","Base.LargeBranch","Base.Twigs","Base.Sapling" }) do
+    local items = inv:getItemsFromFullType(full)
+    if items then
+      for i=0, items:size()-1 do
+        ISTimedActionQueue.add(ISDropItemAction:new(p, items:get(i)))
+      end
+    end
+  end
+end
+
 function AutoChopTask.startAreaJob(p)
   if not AutoChopTask.chopRect then p:Say("Set chop area first."); return end
   if not AFCore.getStockpile() then p:Say("Designate wood pile first."); return end
@@ -11,12 +23,11 @@ function AutoChopTask.startAreaJob(p)
   if #trees == 0 then p:Say("No trees in chop area."); return end
 
   local n = AFCore.queueChops(p, trees)
-  ISTimedActionQueue.add(AFInstant:new(p, function()
-    AFCore.dropTreeLootNow(p)
-  end))
+  ISTimedActionQueue.add(AFInstant:new(p, function() dropTreeLootNow(p) end))
   p:Say(("Queued %d tree(s)."):format(n))
 
   local rect = AutoChopTask.gatherRect or AutoChopTask.chopRect
+  ISTimedActionQueue.add(AFInstant:new(p, function() p:Say("Sweeping and hauling…") end))
   AFSweep.enqueueSweep(p, rect)
   AFSweep.enqueueHaulToPile(p, AFCore.getStockpile())
 end

--- a/42/media/lua/client/AutoForester_Context.lua
+++ b/42/media/lua/client/AutoForester_Context.lua
@@ -1,28 +1,37 @@
-require "AutoForester_Core"
+-- media/lua/client/AutoForester_Context.lua
+require "AutoForester_Debug"
 require "AF_SelectAdapter"
 require "AutoChopTask"
-require "AutoForester_Debug"
+require "AutoForester_Core"
 
 local function addMenu(playerIndex, context, worldObjects, test)
   if test then return end
-  AFLOG("menu", "playerIndex=", tostring(playerIndex), "wos#=", tostring(worldObjects and #worldObjects or 0))
-  local p = getSpecificPlayer(playerIndex or 0); if not p then return end
+  local p = getSpecificPlayer(playerIndex or 0); if not p or not p:isAlive() then return end
 
+  -- Wood pile
   context:addOption("Designate Wood Pile Here", worldObjects, function()
     AF_Select.pickSquare(worldObjects, p, function(sq)
       if not sq then p:Say("No tile."); return end
       AFCore.setStockpile(sq)
       p:Say("Wood pile set.")
-      AFLOG("pile", "sq=", tostring(sq), sq and (sq:getX()..","..sq:getY()..","..sq:getZ()) or "nil")
     end)
   end)
 
+  if AFCore.getStockpile() then
+    context:addOption("Clear Wood Pile Marker", worldObjects, function()
+      AFCore.clearStockpile()
+      p:Say("Wood pile cleared.")
+    end)
+  end
+
+  -- Area select (drag & release)
   context:addOption("Chop Area: Drag & Release", worldObjects, function()
     AF_Select.pickArea(worldObjects, p, function(rect, area)
       if not rect then p:Say("No area."); return end
       AutoChopTask.chopRect = rect
-      AFLOG("select", "rect=", rect and (rect[1]..","..rect[2].."->"..rect[3]..","..rect[4]) or "nil")
-      p:Say(("Chop area: %dx%d"):format(area.areaWidth, area.areaHeight))
+      local w = (area and area.areaWidth) or (rect[3]-rect[1]+1)
+      local h = (area and area.areaHeight) or (rect[4]-rect[2]+1)
+      p:Say(("Chop area: %dx%d."):format(w,h))
     end, "chop")
   end)
 
@@ -30,24 +39,17 @@ local function addMenu(playerIndex, context, worldObjects, test)
     AF_Select.pickArea(worldObjects, p, function(rect, area)
       if not rect then p:Say("No area."); return end
       AutoChopTask.gatherRect = rect
-      AFLOG("select", "rect=", rect and (rect[1]..","..rect[2].."->"..rect[3]..","..rect[4]) or "nil")
-      p:Say(("Gather area: %dx%d"):format(area.areaWidth, area.areaHeight))
+      local w = (area and area.areaWidth) or (rect[3]-rect[1]+1)
+      local h = (area and area.areaHeight) or (rect[4]-rect[2]+1)
+      p:Say(("Gather area: %dx%d."):format(w,h))
     end, "gather")
   end)
 
+  -- Start
   context:addOption("Start AutoForester (Area)", worldObjects, function()
     AutoChopTask.startAreaJob(p)
   end)
-
-  context:addOption("AF: Dump State (debug)", worldObjects, function()
-    local c = AutoChopTask
-    AFSAY(p, ("phase=area trees=%s chopRect=%s gatherRect=%s pile=%s"):format(
-      "n/a",
-      tostring(c and c.chopRect),
-      tostring(c and c.gatherRect),
-      tostring(AFCore.getStockpile())
-    ))
-  end)
 end
 
-Events.OnFillWorldObjectContextMenu.Add(addMenu)
+Events.OnFillWorldObjectContextMenu.Add(addMenu)  -- only once; remove any duplicates
+

--- a/42/media/lua/client/AutoForester_Debug.lua
+++ b/42/media/lua/client/AutoForester_Debug.lua
@@ -1,12 +1,7 @@
-AFDBG = { on = true, chat = true }
+-- media/lua/client/AutoForester_Debug.lua
+AutoForester_Debug = AutoForester_Debug or { level = 2 } -- 0=silent,1=chat,2=chat+console
+local function _say(p, ...) if p and AutoForester_Debug.level >= 1 then p:Say(table.concat({...}," ")) end end
+local function _log(tag, ...) if AutoForester_Debug.level >= 2 then print("[AF]["..tag.."] "..table.concat({...}," ")) end end
+function AFSAY(p, ...) _say(p, ...) end
+function AFLOG(tag, ...) _log(tag, ...) end
 
-function AFLOG(tag, ...)
-  if not AFDBG.on then return end
-  local parts = {}
-  for i=1,select("#", ...) do parts[i] = tostring(select(i, ...)) end
-  print(("[AF] %s: %s"):format(tag, table.concat(parts, " ")))
-end
-
-function AFSAY(p, msg)
-  if AFDBG.chat and p then p:Say(tostring(msg)) end
-end


### PR DESCRIPTION
## Summary
- replace context menu handler and add chop/gather/wood pile actions
- unhighlight and log stockpile markers, improve tree detection and chop queuing
- rework selection adapters and fallback area tool with debug-level logging

## Testing
- `luac -p 42/media/lua/client/AutoForester_Context.lua 42/media/lua/client/AutoForester_Core.lua 42/media/lua/client/AutoChopTask.lua 42/media/lua/client/AF_SelectAdapter.lua 42/media/lua/client/AF_SelectArea.lua 42/media/lua/client/AutoForester_Debug.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a65be542ec832e88861138efc5a2e6